### PR TITLE
PDL via proxy kun v/ Open-Am tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # omsorgspenger-proxy
 
-Proxy for at omsorgspenger-tjenester i gcp kan kalle tjenester i fss  
-Tjenester dekket:
-* /pdl (post)
-* /oppgave (get/post)
+Proxy for at omsorgspenger-tjenester i gcp kan kalle tjenester i fss.
+Tjenesten krever Azure-tokens og veksler til hva den bakomforliggende tjenesten trenger.
+
+## Tjenester dekker
+* /active-directory/me/memberOf (get) - Kun når Open-AM token er i bruk - ellers kan man hente det fra Azure token claim `groups`
+* /dokarkivproxy (put)
+* /infotrygd-grunnlag-paaroerende-sykdom (get) - Token må scopes til nevnte tjeneste, ikke proxy. Den støtter selv Azure-tokens.
+* /k9-sak (kun enkelte endepunkt - se `K9SakRoute`)
+* /open-am/keys (get) - Public endepunkt, krever ingen tokens.
+* /oppgave (get & post)
+* /pdl (post & options) - Kun når Open-AM token er i bruk - ellers kan må gå rett mot PDL.
+* /saf/graphql (post)
+* /sak (get & post)
 
 ### Bruk
 omsorgspenger-proxy har en route per proxyet tjeneste, som beskrevet over. Alt etter dette i url'en blir proxyet videre.   

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,9 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val junitJupiterVersion = "5.7.2"
-val dusseldorfVersion = "1.5.4.257334d"
+val dusseldorfVersion = "2.1.6.0-d31132e"
 val ktorVersion = ext.get("ktorVersion").toString()
+val fuelVersion = "2.3.1"
 
 val jsonassertVersion = "1.5.0"
 val assertjVersion = "3.19.0"
@@ -11,7 +12,7 @@ val assertjVersion = "3.19.0"
 val mainClass = "no.nav.omsorgspenger.AppKt"
 
 plugins {
-    kotlin("jvm") version "1.5.0"
+    kotlin("jvm") version "1.5.10"
     id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
@@ -21,7 +22,7 @@ java {
 }
 
 buildscript {
-    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/257334dab1e72da3cfdb6c3eb0f9f098a3a2b810/gradle/dusseldorf-ktor.gradle.kts")
+    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/d31132e7b259b8f82b510aabe61b05e2b35ff261/gradle/dusseldorf-ktor.gradle.kts")
 }
 
 dependencies {
@@ -30,6 +31,8 @@ dependencies {
     implementation("no.nav.helse:dusseldorf-ktor-auth:$dusseldorfVersion")
     implementation("no.nav.helse:dusseldorf-ktor-core:$dusseldorfVersion")
     implementation("no.nav.helse:dusseldorf-ktor-client:$dusseldorfVersion")
+    implementation("com.github.kittinunf.fuel:fuel:$fuelVersion")
+    implementation("com.github.kittinunf.fuel:fuel-coroutines:$fuelVersion")
     implementation("no.nav.helse:dusseldorf-oauth2-client:$dusseldorfVersion")
     implementation("no.nav.helse:dusseldorf-ktor-metrics:$dusseldorfVersion")
 

--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -26,13 +26,8 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: omsorgspenger-sak
-          namespace: omsorgspenger
           cluster: {{clusterGcp}}
         - application: omsorgspenger-journalforing
-          namespace: omsorgspenger
-          cluster: {{clusterGcp}}
-        - application: k9-personopplysninger
           namespace: omsorgspenger
           cluster: {{clusterGcp}}
         - application: omsorgspenger-tilgangsstyring

--- a/src/main/kotlin/no/nav/omsorgspenger/App.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/App.kt
@@ -83,17 +83,18 @@ internal fun Application.app(applicationContext: ApplicationContext = Applicatio
         DefaultProbeRoutes()
         OpenAmPublicRoute(openAm = openAm)
         authenticate(*issuers.azureAnyScoped()) {
-            PdlRoute(
-                pdlConfig = Config.PDL(applicationContext.env),
-                authConfig = Config.Auth(applicationContext.env),
-                stsClient = stsClient,
-                openAm = openAm
-            )
+            // Underliggende tjenester støtter Azure-tokens, men ikke tilgjengeliggjort i GCP
             InfotrygdGrunnlagPaaroerendeSykdomRoute(
                 config = Config.InfotrygdGrunnlagPaaroerendeSykdom(applicationContext.env)
             )
         }
         authenticate(*issuers.azureProxyScoped()) {
+            // Underliggende tjenester støtter ikke Azure-tokens, veksler til tokens de støtter.
+            PdlRoute(
+                pdlConfig = Config.PDL(applicationContext.env),
+                stsClient = stsClient,
+                openAm = openAm
+            )
             OppgaveRoute(
                 oppgaveConfig = Config.Oppgave(applicationContext.env),
                 stsClient = stsClient

--- a/src/main/kotlin/no/nav/omsorgspenger/Auth.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/Auth.kt
@@ -1,9 +1,6 @@
 package no.nav.omsorgspenger
 
 import com.auth0.jwt.interfaces.Claim
-import io.ktor.application.*
-import io.ktor.auth.*
-import io.ktor.auth.jwt.*
 import kotlinx.coroutines.runBlocking
 import no.nav.helse.dusseldorf.ktor.auth.*
 import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.httpGet
@@ -104,6 +101,3 @@ internal object Auth {
         requireNotNull(json.getString("issuer")) to URI(requireNotNull(json.getString("jwks_uri")))
     }}
 }
-
-internal fun ApplicationCall.erScopetTilOmsorgspengerProxy(omsorgspengerProxyClientId: String) =
-    principal<JWTPrincipal>()!!.payload.audience.contains(omsorgspengerProxyClientId)

--- a/src/main/kotlin/no/nav/omsorgspenger/OpenAm.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/OpenAm.kt
@@ -16,20 +16,20 @@ internal class OpenAm(
     private val issuerOgJwksUri = openAmConfig.wellKnownUri.discover()
     internal val jwksUri = issuerOgJwksUri.second
 
-    private val jwtVerifier = {
-        JwtVerifier(
-            issuer = Issuer(
-                alias = "open_am",
-                issuer = issuerOgJwksUri.first,
-                jwksUri = issuerOgJwksUri.second,
-                audience = null
-            ),
-            additionalClaimRules = setOf(EnforceEqualsOrContains(
+    private val jwtVerifier = JwtVerifier(
+        issuer = Issuer(
+            alias = "open_am",
+            issuer = issuerOgJwksUri.first,
+            jwksUri = issuerOgJwksUri.second,
+            audience = null
+        ),
+        additionalClaimRules = setOf(
+            EnforceEqualsOrContains(
                 defaultClaimName = "tokenName",
                 expected = "id_token"
-            ))
+            )
         )
-    }()
+    )
 
     private fun verifisert(call: ApplicationCall) : Pair<String, DecodedJWT> {
         require(call.harOpenAmToken()) {

--- a/src/main/kotlin/no/nav/omsorgspenger/config/Config.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/config/Config.kt
@@ -45,10 +45,6 @@ internal object Config {
         internal val wellKnownUri = URI(env.getOrFail("OPEN_AM_WELL_KNOWN_URL"))
     }
 
-    internal class Auth(env: Map<String, String>) {
-        internal val azureAppClientId = env.getOrFail("AZURE_APP_CLIENT_ID")
-    }
-
     internal class Ldap(env: Map<String, String>) {
         internal val url = env.getOrFail("LDAP_URL")
         internal val username = env.getOrFail("LDAP_USERNAME")

--- a/src/main/kotlin/no/nav/omsorgspenger/sts/StsRestClient.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/sts/StsRestClient.kt
@@ -18,7 +18,8 @@ internal class StsRestClient(
         ClientSecretAccessTokenClient(
             clientId = serviceUserConfig.username,
             clientSecret = serviceUserConfig.password,
-            tokenEndpoint = URI(stsConfig.url)
+            tokenEndpoint = URI(stsConfig.url),
+            authenticationMode = ClientSecretAccessTokenClient.AuthenticationMode.BASIC
         )
     )
 

--- a/src/test/kotlin/no/nav/omsorgspenger/testutils/MockedEnvironment.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/testutils/MockedEnvironment.kt
@@ -1,11 +1,9 @@
 package no.nav.omsorgspenger.testutils
 
 import no.nav.helse.dusseldorf.testsupport.wiremock.*
-import no.nav.omsorgspenger.testutils.mocks.TokenResponseTransformer
 import no.nav.omsorgspenger.testutils.mocks.stubDokarkivproxy
 import no.nav.omsorgspenger.testutils.mocks.stubOppgave
 import no.nav.omsorgspenger.testutils.mocks.stubPdl
-import no.nav.omsorgspenger.testutils.mocks.tokenTransformerMatcher
 
 internal class MockedEnvironment(
     wireMockPort: Int = 8082
@@ -15,9 +13,6 @@ internal class MockedEnvironment(
         .withPort(wireMockPort)
         .withAzureSupport()
         .withNaisStsSupport()
-        .wireMockConfiguration {
-            it.extensions(TokenResponseTransformer(tokenTransformerMatcher))
-        }
         .build()
         .stubPdl()
         .stubOppgave()

--- a/src/test/kotlin/no/nav/omsorgspenger/testutils/mocks/PdlMock.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/testutils/mocks/PdlMock.kt
@@ -4,65 +4,28 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.containing
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
-import com.github.tomakehurst.wiremock.common.FileSource
-import com.github.tomakehurst.wiremock.extension.Parameters
-import com.github.tomakehurst.wiremock.extension.ResponseTransformer
-import com.github.tomakehurst.wiremock.http.HttpHeader
-import com.github.tomakehurst.wiremock.http.HttpHeaders
-import com.github.tomakehurst.wiremock.http.Request
-import com.github.tomakehurst.wiremock.http.Response
 import com.github.tomakehurst.wiremock.matching.AnythingPattern
-import no.nav.omsorgspenger.NavConsumerToken
+import io.ktor.http.*
 
 private const val pdlUrlPath = "/pdl-mock"
 
-internal const val tokenTransformerMatcher = " tokenTransformerMatcher"
-internal const val likeHeadersBody = "like"
-internal const val ulikeHeadersBody = "ulike"
 internal const val ProxiedHeader = "Proxiedheader"
+internal const val PdlOk = "hello-from-pdl"
 
 internal fun WireMockServer.stubPdl(): WireMockServer {
     WireMock.stubFor(
         WireMock.post(WireMock.urlPathMatching(".*$pdlUrlPath.*"))
-            .withHeader(io.ktor.http.HttpHeaders.Authorization, containing("Bearer"))
-            .withHeader(io.ktor.http.HttpHeaders.ContentType, equalTo("application/json"))
+            .withHeader(HttpHeaders.Authorization, containing("Bearer"))
+            .withHeader(HttpHeaders.ContentType, equalTo("application/json"))
             .withHeader(ProxiedHeader, AnythingPattern())
             .willReturn(
                 WireMock.aResponse()
-                    .withTransformers(tokenTransformerMatcher)
+                    .withStatus(200)
+                    .withBody(PdlOk)
             )
     )
 
     return this
-}
-
-internal class TokenResponseTransformer(
-    private val name: String
-) : ResponseTransformer() {
-
-    override fun getName() = name
-    override fun applyGlobally() = false
-
-    override fun transform(
-        request: Request,
-        response: Response?,
-        files: FileSource?,
-        parameters: Parameters?
-    ): Response {
-        val authorizationHeader = request.getHeader(io.ktor.http.HttpHeaders.Authorization)
-        val navConsumerTokenHeader = request.getHeader(NavConsumerToken)
-
-        val responseBody = if (authorizationHeader == navConsumerTokenHeader)
-            likeHeadersBody
-        else
-            ulikeHeadersBody
-
-        return Response.Builder.like(response)
-            .status(200)
-            .headers(HttpHeaders(HttpHeader.httpHeader(io.ktor.http.HttpHeaders.ContentType, "application/json; charset=UTF-8")))
-            .body(responseBody)
-            .build()
-    }
 }
 
 internal fun WireMockServer.pdlUrl(): String = baseUrl() + pdlUrlPath


### PR DESCRIPTION
- Støtter kun Proxy scoped Azure token + Open-Am token for PDL. Andre er endret til å gå rett på PDL.
- Fjerner k9-personopplysninger & omsorgspenger-sak som nå ikke lengre bruker Proxyen.
- Oppdaterer dependencies
- Oppdaterer readme